### PR TITLE
Fix head drift when setting it stiff.

### DIFF
--- a/reachy_sdk_server/reachy_sdk_server.py
+++ b/reachy_sdk_server/reachy_sdk_server.py
@@ -260,7 +260,7 @@ class ReachySDKServer(Node,
                 names.append(name)
                 values.append(cmd.compliant.value)
 
-                if not cmd.compliant.value:
+                if not cmd.compliant.value and self.joints[name]['compliant']:
                     # If turning stiff we reset any obsolete goal_position we may have
                     self.joints[name]['goal_position'] = self.joints[name]['present_position']
 


### PR DESCRIPTION
Due to imprecision in the forward kinematics of the head, we avoid resetting its goal position every time we set it stiff.
We only do this when it actually goes from compliant to stiff.